### PR TITLE
Refactor/storage per session

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,7 @@ func main() {
 	router.Use(cors.Default())
 
 	router.GET("/scrape", handlers.ScrapeHandler)
-	router.GET("/scrape/:id/:page", handlers.PageHandler)
+	router.GET("/scrape/:session_id/:id/:page", handlers.PageHandler)
 
 	log.Fatal(router.Run(fmt.Sprintf(":%s", config.GetAppPort())))
 }

--- a/models/response.go
+++ b/models/response.go
@@ -26,6 +26,7 @@ type PaginatedURLs struct {
 
 type PageResponse struct {
 	RequestID  string      `json:"request_id"`
+	SessionId  string      `json:"session_id"`
 	Pagination Pagination  `json:"pagination"`
 	Scraped    ScrapedData `json:"scraped"`
 }

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -5,38 +5,93 @@
 package storage
 
 import (
+	"fmt"
 	"math/rand"
+	"scraper/logger"
 	"scraper/models"
 	"sync"
 	"time"
 )
 
-var storage = struct {
+// Database registry to store dbs per user session
+// Here we set the initial capacity to 10000 to reduce resizing overhead.
+var dbRegistry = struct {
 	sync.RWMutex
-	data map[string]models.PageInfo
-}{data: make(map[string]models.PageInfo)}
+	dbs map[string]Database
+}{dbs: make(map[string]Database, 10_000)}
 
-// This is to store page info.
-func StorePageInfo(info *models.PageInfo) string {
-	storage.Lock()
-	defer storage.Unlock()
+type Database interface {
+	StorePageInfo(info *models.PageInfo) string
+	RetrievePageInfo(id string) (*models.PageInfo, bool)
+}
 
-	id := generateID()
-	storage.data[id] = *info
+type InMemoryDatabase struct {
+	sync.RWMutex
+	Data map[string]models.PageInfo
+}
+
+// This is to retrieve the database by session ID.
+// If the database does not exist, it will create a new one for the current session.
+// Here we set the initial capacity to 10000 to reduce resizing overhead.
+func RetriveDatabase(sessionID string) Database {
+	dbRegistry.RLock()
+	defer dbRegistry.RUnlock()
+
+	db, exists := dbRegistry.dbs[sessionID]
+	if !exists {
+		db = &InMemoryDatabase{Data: make(map[string]models.PageInfo, 10_000)}
+		dbRegistry.dbs[sessionID] = db
+	}
+	return db
+}
+
+// This is to store page info in the given database.
+func (db *InMemoryDatabase) StorePageInfo(info *models.PageInfo) string {
+	db.Lock()
+	defer db.Unlock()
+
+	id := GenerateID()
+	db.Data[id] = *info
+	logger.Debug(fmt.Sprintf("Updated database with page info:\n %v", db.Data))
 	return id
 }
 
-// This is to retrieve page info by unique ID.
-func RetrievePageInfo(id string) (*models.PageInfo, bool) {
-	storage.RLock()
-	defer storage.RUnlock()
+// This is to retrieve page info by unique ID from the given database.
+func (db *InMemoryDatabase) RetrievePageInfo(id string) (*models.PageInfo, bool) {
+	db.RLock()
+	defer db.RUnlock()
 
-	info, exists := storage.data[id]
+	info, exists := db.Data[id]
+	logger.Debug(fmt.Sprintf("Retrieved page info from:\n %v", db.Data))
 	return &info, exists
 }
 
+// var storage = struct {
+// 	sync.RWMutex
+// 	data map[string]models.PageInfo
+// }{data: make(map[string]models.PageInfo)}
+
+// // This is to store page info.
+// func StorePageInfo(info *models.PageInfo) string {
+// 	storage.Lock()
+// 	defer storage.Unlock()
+
+// 	id := generateID()
+// 	storage.data[id] = *info
+// 	return id
+// }
+
+// // This is to retrieve page info by unique ID.
+// func RetrievePageInfo(id string) (*models.PageInfo, bool) {
+// 	storage.RLock()
+// 	defer storage.RUnlock()
+
+// 	info, exists := storage.data[id]
+// 	return &info, exists
+// }
+
 // This is to generate the random unique ID.
-func generateID() string {
+func GenerateID() string {
 	return time.Now().Format("20060102150405") + "-" + randomString(8)
 }
 

--- a/storage/memory_test.go
+++ b/storage/memory_test.go
@@ -12,12 +12,13 @@ func TestStorePageInfo(test_type *testing.T) {
 		Title: "Test Page",
 	}
 
-	id := StorePageInfo(pageInfo)
+	database := RetriveDatabase("test-session")
+	id := database.StorePageInfo(pageInfo)
 
 	// Ensure the ID is not empty
 	assert.NotEmpty(test_type, id, "Generated ID should not be empty")
 
-	retrievedInfo, exists := RetrievePageInfo(id)
+	retrievedInfo, exists := database.RetrievePageInfo(id)
 
 	// Assert that the PageInfo exists
 	assert.True(test_type, exists, "Stored PageInfo should be retrievable")
@@ -26,8 +27,9 @@ func TestStorePageInfo(test_type *testing.T) {
 }
 
 func TestRetrievePageInfo_NotFound(test_type *testing.T) {
+	database := RetriveDatabase("test-session")
 	// Try retrieving a non-existent PageInfo
-	retrievedInfo, exists := RetrievePageInfo("nonexistent-id")
+	retrievedInfo, exists := database.RetrievePageInfo("nonexistent-id")
 
 	// Assert that the info does not exist
 	assert.False(test_type, exists, "Non-existent ID should not be found")
@@ -39,7 +41,8 @@ func TestRetrievePageInfo_NotFound(test_type *testing.T) {
 func TestGenerateID(test_type *testing.T) {
 	// Call the private function indirectly by calling StorePageInfo
 	pageInfo := &models.PageInfo{Title: "Test Page"}
-	id := StorePageInfo(pageInfo)
+	database := RetriveDatabase("test-session")
+	id := database.StorePageInfo(pageInfo)
 
 	// Assert that the ID follows the expected format
 	assert.Regexp(test_type, `^\d{14}-[a-zA-Z0-9]{8}$`, id,

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -27,20 +27,21 @@ func min(a, b int) int {
 }
 
 // This is to build the response after a successful scraping.
-func BuildPageResponse(requestID string, pageNum, totalPages int, pageInfo *models.PageInfo,
-	inaccessible, start, end int) models.PageResponse {
+func BuildPageResponse(requestID string, sessionID string, pageNum, totalPages int,
+	pageInfo *models.PageInfo, inaccessible, start, end int) models.PageResponse {
 	var prevPage, nextPage *string
 	if pageNum > 1 {
-		prev := fmt.Sprintf("/scrape/%s/%d", requestID, pageNum-1)
+		prev := fmt.Sprintf("/scrape/%s/%s/%d", sessionID, requestID, pageNum-1)
 		prevPage = &prev
 	}
 	if end < len(pageInfo.URLs) {
-		next := fmt.Sprintf("/scrape/%s/%d", requestID, pageNum+1)
+		next := fmt.Sprintf("/scrape/%s/%s/%d", sessionID, requestID, pageNum+1)
 		nextPage = &next
 	}
 
 	return models.PageResponse{
 		RequestID: requestID,
+		SessionId: sessionID,
 		Pagination: models.Pagination{
 			PageSize:    config.GetURLCheckPageSize(),
 			CurrentPage: pageNum,


### PR DESCRIPTION
* Refactored the existing in-memory database to create databases per user session.

### How to try

1. For the initial request, trigger: `http://localhost:8080/scrape?url=https://google.com`
2. Subsequent pagination URLs will be generated with the session ID. ie: `http://localhost:8080/scrape/<session-id>/<request-id>/<page>`
3. To utilize the same session (same database) for subsequent new scraping requests, add the `session_id` query parameter to the URL. ie: `http://localhost:8080/scrape?url=https://google.com&session_id=<session-id-from-prev-req>`